### PR TITLE
Fix Flags trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ Implement serde traits for bitflags 2.x types compatibly with 1.x.
 exclude = [".github"]
 
 [dependencies.bitflags]
-version = "2.0.0-beta.1"
+version = "^2.3"
 
 [dependencies.serde]
 version = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,17 +48,17 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use bitflags::BitFlags;
+use bitflags::Flags;
 
 /// Serialize a flags type equivalently to how `#[derive(Serialize)]` on a flags type
 /// from `bitflags` `1.x` would.
-pub fn serialize<T: BitFlags, S: Serializer>(
+pub fn serialize<T: Flags, S: Serializer>(
     flags: &T,
     name: &'static str,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
-    <T as BitFlags>::Bits: Serialize,
+    T::Bits: Serialize,
 {
     let mut serialize_struct = serializer.serialize_struct(name, 1)?;
     serialize_struct.serialize_field("bits", &flags.bits())?;
@@ -67,12 +67,12 @@ where
 
 /// Deserialize a flags type equivalently to how `#[derive(Deserialize)]` on a flags type
 /// from `bitflags` `1.x` would.
-pub fn deserialize<'de, T: BitFlags, D: Deserializer<'de>>(
+pub fn deserialize<'de, T: Flags, D: Deserializer<'de>>(
     name: &'static str,
     deserializer: D,
 ) -> Result<T, D::Error>
 where
-    <T as BitFlags>::Bits: Deserialize<'de>,
+    T::Bits: Deserialize<'de>,
 {
     struct BitsVisitor<T>(core::marker::PhantomData<T>);
 


### PR DESCRIPTION
In `bitflags` `2.3`, the `BitFlags` trait was rejigged so its associated type moved to a supertrait. That broke the specific way we were using it in this library. Since the trait is deprecated anyways this just moves it forwards to `Flags`, which is semver-compatible.