### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ in your project.
 Add `bitflags-serde-legacy` to your `Cargo.toml`:
 
 ```toml
-[dependencies.bitflags_serde_legacy]
+[dependencies.bitflags-serde-legacy]
 version = "0.1.1"
 ```
 


### PR DESCRIPTION
crates.io name is [bitflags-serde-legacy](https://crates.io/crates/bitflags-serde-legacy) not `bitflags_serde_legacy`